### PR TITLE
Carousel custom buttons

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@himalaya-ui/core",
-  "version": "0.4.9",
+  "version": "0.4.10",
   "main": "dist/bundle/index.js",
   "module": "dist/bundle/esm/index.js",
   "types": "dist/bundle/esm/index.d.ts",

--- a/src/components/carousel/carousel-buttons.tsx
+++ b/src/components/carousel/carousel-buttons.tsx
@@ -1,0 +1,26 @@
+'use client';
+
+import React from 'react';
+import { ArrowLeft, ArrowRight } from '../icons';
+
+export const CarouselButtons: React.FC<React.JSX.IntrinsicElements['div']> = ({children}) => {
+    const defaultArrows = <div className="splide__arrows">
+                                <button className="splide__arrow splide__arrow--prev" type="button">
+                                    <div className="splide__arrow__inner">
+                                        <ArrowLeft />
+                                    </div>
+                                </button>
+                                <button className="splide__arrow splide__arrow--next" type="button">
+                                    <div className="splide__arrow__inner">
+                                        <ArrowRight />
+                                    </div>
+                                </button>
+                            </div>
+
+    const arrows = React.Children.count(children) > 0 ? children : defaultArrows
+  return (
+        <>
+            {arrows}
+        </>
+    );
+};

--- a/src/components/carousel/carousel.tsx
+++ b/src/components/carousel/carousel.tsx
@@ -1,6 +1,5 @@
 'use client';
 
-import { ArrowLeft, ArrowRight } from '../icons';
 import { Splide as SplideCore } from '@splidejs/splide';
 import React, { useEffect, useLayoutEffect } from 'react';
 import { SliderOptions, SplideProps } from '.';
@@ -12,6 +11,7 @@ import { CarouselTrack } from './carousel-track';
 import { EVENTS } from './constants/events';
 import { classNames, merge } from './utils';
 import { omit } from 'lodash';
+import { CarouselButtons } from './carousel-buttons';
 
 const classOverride = {
   arrows: 'carousel_arrows',
@@ -34,7 +34,7 @@ const CarouselComponent: React.FC<React.PropsWithChildren<SplideProps>> = ({
 }) => {
   const { SCALES } = useScale();
   const splideRef = React.createRef<HTMLDivElement>();
-  const [, slides] = pickChild(children, CarouselItem);
+  const [buttons, slides] = pickChild(children, CarouselItem);
   let splide: SplideCore | undefined = undefined;
 
   const cleanUp = () => {
@@ -98,18 +98,8 @@ const CarouselComponent: React.FC<React.PropsWithChildren<SplideProps>> = ({
       <div className={classNames('splide', className)} ref={splideRef} {...htmlOps}>
         <div className="splide-inner">
           <CarouselTrack>{slides}</CarouselTrack>
-          <div className="splide__arrows">
-            <button className="splide__arrow splide__arrow--prev" type="button">
-              <div className="splide__arrow__inner">
-                <ArrowLeft />
-              </div>
-            </button>
-            <button className="splide__arrow splide__arrow--next" type="button">
-              <div className="splide__arrow__inner">
-                <ArrowRight />
-              </div>
-            </button>
-          </div>
+
+          <CarouselButtons>{buttons}</CarouselButtons>
         </div>
         <ul className="splide__pagination"></ul>
       </div>


### PR DESCRIPTION
## Checklist

- [ ] Fix linting errors
- [ ] Tests have been added / updated (or snapshots)

## Change information

Update carousel components to accept the Custom JSX for buttons. We will pass jsx as follows just after the last carousel item:
                             `<div className="splide__arrows">
                                <button className="splide__arrow splide__arrow--prev" type="button">
                                    <div className="splide__arrow__inner">
                                        <ArrowLeft />
                                    </div>
                                </button>
                                <button className="splide__arrow splide__arrow--next" type="button">
                                    <div className="splide__arrow__inner">
                                        <ArrowRight />
                                    </div>
                                </button>
                            </div>`

And in this jsx we can pass our own icons for previous and next buttons. If no jsx is passed then default buttons will be used.